### PR TITLE
[Feature] Smart(er) URL parsing

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,31 @@
+name: Lint and Test
+on:
+  - pull_request
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - if: env.ACT == 'true'
+        run: |
+          apt-get update && apt-get install -y unzip && apt-get clean
+      - uses: JohnnyMorganz/stylua-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: "latest"
+          args: --check .
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+      - uses: actions/checkout@v4
+      - if: env.ACT == 'true'
+        run: |
+          apt-get update
+          apt-get install -y make git
+          apt-get clean
+      - run: |
+          make test

--- a/Makefile
+++ b/Makefile
@@ -56,4 +56,8 @@ panvimdoc-build:
 		echo "Not using docker"; \
 	fi
 
+.PHONY: test
+test:
+	nvim --headless --clean -c 'set runtimepath+=.' -c 'lua require("git-dev.parser_spec").run()' -c qa
+
 # vim: ft=make ts=4 noexpandtab

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ shallow clones automatically. It aims to provide a similar experience to
 - [:notebook: Recipes](#notebook-recipes)
   - [:grey_question: Interactive Opening](#grey_question-interactive-opening)
   - [:evergreen_tree: nvim-tree](#evergreen_tree-nvim-tree)
+  - [:evergreen_tree: neo-tree](#evergreen_tree-neo-tree)
   - [:bookmark_tabs: New tab](#bookmark_tabs-new-tab)
   - [:fox_face: Web browser](#fox_face-web-browser)
-  - [:lower_left_paintbrush: Customize URI](#lower_left_paintbrush-customize-uri)
+  - [:pencil: Customizing Default URL](#pencil-customizing-default-url)
   - [:house_with_garden: Private Git Instance](#house_with_garden-private-git-instance)
   - [:telescope: Telescope](#telescope-telescope)
 - [:crystal_ball: Future Plans / Thoughts](#crystal_ball-future-plans--thoughts)
@@ -74,6 +75,17 @@ Use your favorite plugin manager:
   opts = {},
 }
 ```
+
+Lazier (documentation will not be available until first use):
+```lua
+{
+  "moyiz/git-dev.nvim",
+  lazy = true,
+  cmd = { "GitDevOpen", "GitDevCleanAll" },
+  opts = {},
+}
+```
+
 See [Options](#gear-options).
 
 <!-- panvimdoc-ignore-end -->
@@ -291,10 +303,24 @@ To open with [nvim-tree](https://github.com/nvim-tree/nvim-tree.lua):
 
 ```lua
 opts = {
-  opener = function(dir)
-    -- vim.cmd("Neotree " .. dir)
+  opener = function(dir, _, selected_path)
     -- vim.cmd("Oil " .. vim.fn.fnameescape(dir))
     vim.cmd("NvimTreeOpen " .. vim.fn.fnameescape(dir))
+    if selected_path then
+      vim.cmd("edit " .. selected_path)
+    end
+  end
+}
+```
+
+### :evergreen_tree: neo-tree
+```lua
+opts = {
+  opener = function(dir, _, selected_path)
+    vim.cmd("Neotree " .. dir)
+    if selected_path then
+      vim.cmd("edit " .. selected_path)
+    end
   end
 }
 ```
@@ -305,28 +331,31 @@ Recommended. Repositories will be opened in a new tab and its CWD will be set.
 ```lua
 opts = {
   cd_type = "tab",
-  opener = function(dir)
+  opener = function(dir, _, selected_path)
     vim.cmd "tabnew"
-    vim.cmd("NvimTreeOpen " .. vim.fn.fnameescape(dir))
+    vim.cmd("Neotree " .. dir)
+    if selected_path then
+      vim.cmd("edit " .. selected_path)
+    end
   end
 }
 ```
 
 ### :fox_face: Web browser
 It does not make much sense on its own, but a showcase for getting both the
-repository URI and the local directory.
+repository URL and the local directory.
 
 ```lua
 opts = {
   cd_type = "none",
-  opener = function(_, repo_uri)
-     -- vim.cmd("!librewolf " .. repo_uri)
-     vim.cmd("!firefox " .. repo_uri)
+  opener = function(_, repo_url)
+     -- vim.cmd("!librewolf " .. repo_url)
+     vim.cmd("!firefox " .. repo_url)
   end
 }
 ```
 
-### :lower_left_paintbrush: Customize URI
+### :pencil: Customizing Default URL
 By default, this plugin accepts partial repository URI (e.g. `org/repo`) by
 applying it onto a format string. This behavior can be customized by setting
 `git.base_uri_format` to change the URI, or `git.default_org` to prepend a
@@ -374,7 +403,15 @@ opts = {
 ```
 Notice that my Gitea service listens on port 2222 for SSH. This custom parser
 tricks `parse_gitea_like_url` by converting a HTTP URL to SSH like URL (which 
-is not a valid git URI). I.e. `https://git.home.arpa/homelab/k8s/src/commit/ef3fec4973042f0e0357a136d927fe2839350170/apps/gitea/kustomization.yaml` ->`ssh://git@git.home.arpa:2222/homelab/k8s/src/commit/ef3fec4973042f0e0357a136d927fe2839350170/apps/gitea/kustomization.yaml`.
+is not a valid git URI). I.e. 
+```
+https://git.home.arpa/homelab/k8s/src/commit/ef3fec4973042f0e0357a136d927fe2839350170/apps/gitea/kustomization.yaml
+```
+To:
+```
+ssh://git@git.home.arpa:2222/homelab/k8s/src/commit/ef3fec4973042f0e0357a136d927fe2839350170/apps/gitea/kustomization.yaml
+```
+
 Then, the parser trims the "domain" and proceeds as usual. Output:
 ```lua
 {

--- a/lua/git-dev/gitcmd.lua
+++ b/lua/git-dev/gitcmd.lua
@@ -1,9 +1,9 @@
 local GitCmd = {}
 
----@class GitCmdInit
+---@class GitCmd
 ---@field cmd? string : Path to `git` command. Default: "git".
 
----@param o GitCmdInit
+---@param o GitCmd
 function GitCmd:init(o)
   o = vim.tbl_deep_extend("force", { cmd = "git" }, o or {})
   setmetatable(o, self)
@@ -30,6 +30,22 @@ function GitCmd:clone(repo_url, repo_dir, branch, extra_args)
   )
 end
 
+---Checks out a branch, tag or commit.
+---@param repo_dir string
+---@param ref string
+---@param extra_args? string
+function GitCmd:checkout(repo_dir, ref, extra_args)
+  return vim.fn.systemlist(
+    self.cmd
+      .. " -C "
+      .. repo_dir
+      .. " checkout "
+      .. (extra_args or "")
+      .. " "
+      .. ref
+  )
+end
+
 ---Refreshes local objects and refs from remote.
 ---@param repo_dir string : Local path to git repository.
 ---@param extra_args? string
@@ -41,7 +57,7 @@ end
 
 ---Hard resets a local repository to given reference.
 ---@param repo_dir string : Local path to git repository.
----@param ref string
+---@param ref? string
 ---@param extra_args? string
 function GitCmd:reset(repo_dir, ref, extra_args)
   return vim.fn.systemlist(
@@ -51,7 +67,7 @@ function GitCmd:reset(repo_dir, ref, extra_args)
       .. " reset --hard "
       .. (extra_args or "")
       .. " "
-      .. ref
+      .. (ref or "")
   )
 end
 

--- a/lua/git-dev/gitcmd.lua
+++ b/lua/git-dev/gitcmd.lua
@@ -1,0 +1,78 @@
+local GitCmd = {}
+
+---@class GitCmdInit
+---@field cmd? string : Path to `git` command. Default: "git".
+
+---@param o GitCmdInit
+function GitCmd:init(o)
+  o = vim.tbl_deep_extend("force", { cmd = "git" }, o or {})
+  setmetatable(o, self)
+  self.__index = self
+  return o
+end
+
+---Clones a git reporitory.
+---@param repo_url string : Remote git repository URL.
+---@param repo_dir string : Local path to git repository.
+---@param branch? string : Optional branch to set.
+---@param extra_args? string
+function GitCmd:clone(repo_url, repo_dir, branch, extra_args)
+  return vim.fn.systemlist(
+    self.cmd
+      .. " clone "
+      .. (extra_args or "")
+      .. " "
+      .. (branch and " -b " .. branch or "")
+      .. " "
+      .. repo_url
+      .. " "
+      .. repo_dir
+  )
+end
+
+---Refreshes local objects and refs from remote.
+---@param repo_dir string : Local path to git repository.
+---@param extra_args? string
+function GitCmd:refresh(repo_dir, extra_args)
+  return vim.fn.systemlist(
+    self.cmd .. " -C " .. repo_dir .. " fetch " .. (extra_args or "")
+  )
+end
+
+---Hard resets a local repository to given reference.
+---@param repo_dir string : Local path to git repository.
+---@param ref string
+---@param extra_args? string
+function GitCmd:reset(repo_dir, ref, extra_args)
+  return vim.fn.systemlist(
+    self.cmd
+      .. " -C "
+      .. repo_dir
+      .. " reset --hard "
+      .. (extra_args or "")
+      .. " "
+      .. ref
+  )
+end
+
+---@class RemoteRef
+---@field commit_id string
+---@field ref string
+
+---Lists all references in a repository by optional pattern.
+---@param repo_url string : Remote git repository URL.
+---@param pattern? string : An optional pattern to filter by.
+---@return RemoteRef[]
+function GitCmd:list_refs(repo_url, pattern)
+  return vim.tbl_map(
+    function(raw_ref)
+      local ref = vim.fn.split(raw_ref, "\t")
+      return { commit_id = ref[1], ref = ref[2] }
+    end,
+    vim.fn.systemlist(
+      self.cmd .. " ls-remote -htq " .. repo_url .. " " .. (pattern or "")
+    )
+  )
+end
+
+return GitCmd

--- a/lua/git-dev/init.lua
+++ b/lua/git-dev/init.lua
@@ -121,6 +121,11 @@ local augroup = vim.api.nvim_create_augroup("GitDev", { clear = true })
 --- `commit` > `tag` > `branch`
 ---@param opts table Override plugin settings.
 M.open = function(repo, ref, opts)
+  if not repo then
+    vim.notify "Missing repository. See |:h git-dev-usage-open|"
+    return
+  end
+
   local config = vim.tbl_deep_extend("force", M.config, opts or {})
 
   if config.verbose then

--- a/lua/git-dev/init.lua
+++ b/lua/git-dev/init.lua
@@ -89,7 +89,7 @@ local function git_uri_to_dir_name(uri, branch)
   local dir_name =
     uri:gsub("/+$", ""):gsub(".*://", ""):gsub("/", "__"):gsub(".git$", "")
   if branch and branch ~= "" then
-    dir_name = dir_name .. "#" .. branch
+    dir_name = dir_name .. "#" .. branch:gsub("/", "__")
   end
   return dir_name
 end

--- a/lua/git-dev/parser.lua
+++ b/lua/git-dev/parser.lua
@@ -1,0 +1,318 @@
+---The Git URI parsing engine.
+
+-- Trims trailing slashes and adds `.git` suffix.
+local function git_suffix(text)
+  -- Trim trailing slashes
+  text = text:gsub("/+$", "")
+
+  -- Ensure `.git` suffix.
+  -- It is optional for many (all?) git vendors.
+  if text:sub(-4, -1) ~= ".git" then
+    text = text .. ".git"
+  end
+  return text
+end
+
+-- Escape non alphanumeric characters for lua pattern matching purposes.
+local function pattern_esc(text)
+  return text:gsub("([^%w])", "%%%1")
+end
+
+-- Checks if given file is a valid git bundle.
+local function is_git_bundle(file_path)
+  local file = io.open(file_path, "rb")
+  if not file then
+    return false
+  end
+  local sig = file:read(6)
+  file:close()
+  return sig == "git\001\n"
+end
+
+---@class Parser
+---@field gitcmd table
+---@field base_uri_format string
+---@field default_org? string
+---@field extra_domain_to_parser? table
+---@field parse function
+local Parser = {}
+
+---@param o Parser
+function Parser:init(o)
+  o = vim.tbl_deep_extend(
+    "force",
+    { base_uri_format = "%s", extra_domain_to_parser = {} },
+    o
+  )
+  setmetatable(o, self)
+  self.__index = self
+  return o
+end
+
+---@class GitRepo
+---@field repo_url string
+---@field full_blob? string
+---@field commit? string
+---@field branch? string
+---@field type "http"|"local"|"bundle"|"raw"|"custom"
+
+-- Since branch / tag might include slashes, it is impossible to determine how
+-- to separate it from the optional trailing file path. `git ls-remote` is used
+-- to find the longest ref name that can be deducted from `text`. If none is
+-- found, it will be tested as a commit ID. If it is invalid as a commit, it
+-- will be notated as `full_blob`. Otherwise, it will be separated to `branch`
+-- and `selected_path`. If there are no slashes, it can be assumed that the
+-- full blob is actually a branch / tag name, and there is no trailed file path.
+function Parser:parse_full_blob(text, repo_url)
+  if not text or text == "" then
+    return {}
+  end
+  if not text:find "/" then
+    return { branch = text }
+  end
+
+  local parts = vim.split(text, "/", { trimempty = true })
+
+  -- The first part must be part of the branch / tag name.
+  local refs = vim.tbl_map(function(ref)
+    return ref.ref
+  end, self.gitcmd:list_refs(repo_url, parts[1] .. "*") or {})
+
+  -- Since refs will be scanned by `find`, it is simpler to just concatenate
+  -- them instead of iterating.
+  local concat_refs = vim.fn.join(refs, "\n")
+
+  local ref
+  for i = 1, #parts do
+    local new_ref = vim.fn.join(vim.list_slice(parts, 1, i), "/")
+    if not concat_refs:find(pattern_esc(new_ref)) then
+      break
+    end
+    ref = new_ref
+  end
+  -- No such ref, first part might still be a commit ID.
+  if not ref then
+    -- If the first part looks like a valid commit ID, it probably is.
+    -- TODO: Find a better way. The repository is not cloned yet.
+    if parts[1]:find("^" .. ("%x"):rep(40) .. "$") then
+      return {
+        commit = parts[1],
+        selected_path = vim.fn.join(vim.list_slice(parts, 2), "/"),
+      }
+    else
+      return { full_blob = text }
+    end
+  end
+
+  -- Generate a selected path and trim leading slash.
+  local selected_path = text:gsub(pattern_esc(ref), ""):sub(2)
+  return {
+    branch = ref,
+    selected_path = selected_path ~= "" and selected_path or nil,
+  }
+end
+
+function Parser:parse_tree_or_full_blob(text, repo_url)
+  local res = {}
+  local branch_or_tag = text:match "^/tree/(.*)$"
+  if branch_or_tag then
+    res.branch = branch_or_tag
+  else
+    -- Full blob contains both the ref and the file path.
+    -- Due to possible branch / tag names that contain `/`, the parser cannot
+    -- determine where the ref ends and the file name begins at this point.
+    local _, sep_end = text:find "^/blob/"
+    if sep_end then
+      res = vim.tbl_deep_extend(
+        "force",
+        res,
+        self:parse_full_blob(text:sub(sep_end + 1), repo_url)
+      )
+    end
+  end
+  return res
+end
+
+function Parser:parse_github_url(url, base_domain)
+  local res = {}
+  local _, end_ = url:find(pattern_esc(base_domain) .. "/([^/]+/[^/]+)")
+
+  res.repo_url = end_ and git_suffix(url:sub(1, end_)) or url
+
+  -- Parse the rest of the URL
+  local tree_or_blob =
+    self:parse_tree_or_full_blob(url:sub(end_ + 1), res.repo_url)
+  return vim.tbl_deep_extend("force", res, tree_or_blob or {})
+end
+
+function Parser:parse_gitlab_url(url)
+  local res = {}
+  -- Gitlab repositories are not limited to `org/repo` notation, but `/-/`
+  -- is used to split repository path from tree / blob.
+  local sep_start, sep_end = url:find "/%-/"
+  if not sep_end then
+    res.repo_url = git_suffix(url)
+    return res
+  end
+  res.repo_url = git_suffix(url:sub(1, sep_start))
+  -- Parse the rest of the URL
+  local tree_or_blob =
+    self:parse_tree_or_full_blob(url:sub(sep_end), res.repo_url)
+  return vim.tbl_deep_extend("force", res, tree_or_blob or {})
+end
+
+function Parser:parse_gitea_like_url(url, base_domain)
+  local res = {}
+  local _, repo_end = url:find(pattern_esc(base_domain) .. "/([^/]+/[^/]+)")
+
+  res.repo_url = repo_end and git_suffix(url:sub(1, repo_end)) or url
+
+  local url_tail = url:sub(repo_end + 1)
+  if url_tail:find "^/raw/" or url_tail:find "^/src/" then
+    -- Trim raw / src
+    url_tail = url_tail:sub(5)
+  end
+
+  local commit, selected_path = url_tail:match "^/commit/([^/]+)/(.*)$"
+  if commit then
+    res.commit = commit
+  end
+  if selected_path then
+    res.selected_path = selected_path
+  end
+
+  if url_tail:find "^/branch" or url_tail:find "^/tag" then
+    res = vim.tbl_deep_extend(
+      "force",
+      res,
+      self:parse_full_blob(
+        url_tail:gsub("^/branch/?", ""):gsub("^/tag/?", ""),
+        res.repo_url
+      )
+    )
+  end
+
+  return res
+end
+
+local domain_to_parser = {
+  ["github.com"] = Parser.parse_github_url,
+  ["gitlab.com"] = Parser.parse_gitlab_url,
+  ["gitea.com"] = Parser.parse_gitea_like_url,
+  ["codeberg.org"] = Parser.parse_gitea_like_url,
+}
+
+---Parses a HTTP repository URL.
+---If domain is mapped to a specific parser, use it. Otherwise treat input as
+---raw repository URI.
+---@param text string
+---@return GitRepo
+function Parser:parse_http(text)
+  local domain = text:match "https?://([^/]+)"
+  local parser
+  if self.extra_domain_to_parser and self.extra_domain_to_parser[domain] then
+    parser = self.extra_domain_to_parser[domain]
+  elseif vim.fn.has_key(domain_to_parser, domain) == 1 then
+    parser = domain_to_parser[domain]
+  else
+    parser = Parser.parse_raw
+  end
+  return vim.tbl_deep_extend(
+    "keep",
+    parser(self, text, domain),
+    { type = "http" }
+  )
+end
+
+---Parses a local repository path.
+---Determines whether it is a Git Bundle, local repository or a file in a local
+---repository.
+---@param path string
+---@return GitRepo?
+function Parser:parse_local_path(path)
+  -- Trim optional `file://` scheme
+  path = path:gsub("file://", "")
+
+  -- Check if `path` is a git bundle
+  if is_git_bundle(path) then
+    return { repo_url = path, type = "bundle" }
+  end
+
+  -- Find local git repository. `path` can be a git repository or a file in a
+  -- git repository. If it is a file, split it into a `repo_url` and
+  -- `selected_path`.
+  -- Unfortunately, `vim.fs.find` does not track paths when traversing upwards.
+  -- The result is not relative to given `path`. The following loop will search
+  -- for a parent path that contains `.git` and will also keep track of the path
+  -- in which the `.git` directory was found (if any).
+  local cur_path, tail = path, ""
+  while cur_path ~= "/" and cur_path ~= "." do
+    if vim.fn.isdirectory(vim.fs.normalize(cur_path .. "/.git")) == 1 then
+      return { repo_url = cur_path, selected_path = tail, type = "local" }
+    end
+    tail = vim.fs.normalize(vim.fs.basename(cur_path) .. "/" .. tail)
+    cur_path = vim.fs.dirname(cur_path)
+  end
+
+  -- If we got here, no part of the given path contains `.git`, and thus it is
+  -- invalid local git repository path.
+  -- return { repo_url = path, type = "raw" }
+end
+
+-- Parses the short form of ssh
+-- [[user][:password]@]<host>[:port]/<repo>
+function Parser:parse_ssh_short(text)
+  if text:find "^[%w_-.]*:?.*@?[%w_-.]+:.*" then
+    return { repo_url = text, type = "ssh" }
+  end
+end
+
+-- Parses given text as a short notation.
+-- It will prefix the text with default organization if given and text does not
+-- contain slashes.
+function Parser:parse_with_base_uri(text)
+  if not text:match "/" and self.default_org and self.default_org ~= "" then
+    text = self.default_org .. "/" .. text
+  end
+  return { repo_url = self.base_uri_format:format(text), type = "base_uri" }
+end
+
+-- "Parses" given text as raw repository.
+function Parser:parse_raw(text)
+  return { repo_url = text, type = "raw" }
+end
+
+---Parses text as git repository URL.
+---@param text string
+---@return GitRepo
+function Parser:parse(text)
+  -- Strip spaces, query parameters and anchors
+  text = text
+    :gsub("^%s+", "")
+    :gsub("%s+$", "")
+    :gsub("#[%w-_.]+$", "")
+    :gsub("%?[%w-_.&=+:]+$", "")
+
+  -- Peek at scheme
+  local _, _, scheme = text:find "^(%w+)://"
+  if scheme == "http" or scheme == "https" then
+    return self:parse_http(text)
+  elseif scheme == "file" then
+    return self:parse_local_path(text) or {}
+  elseif not scheme then
+    -- Scheme is not given. It can be either SSH (short form), local path or
+    -- short repo name (to be applied to `base_uri_format`).
+    -- First, check if `text` corresponds with a local repository, and if not,
+    -- check if `text` corresponds with short ssh format.
+    local parsed = self:parse_local_path(text) or self:parse_ssh_short(text)
+    if parsed then
+      return parsed
+    end
+    -- `text` is probably a short notation to be used with `base_uri_format`
+    return self:parse_with_base_uri(text)
+  end
+
+  return self:parse_raw(text)
+end
+
+return Parser

--- a/lua/git-dev/parser_spec.lua
+++ b/lua/git-dev/parser_spec.lua
@@ -1,0 +1,386 @@
+local T = {}
+T.run = function()
+  local Parser = require "git-dev.parser"
+
+  local test_cases = {
+    -- Github URLs
+    {
+      url = "https://github.com/moyiz/git-dev.nvim/tree",
+      expected = {
+        repo_url = "https://github.com/moyiz/git-dev.nvim.git",
+        type = "http",
+      },
+    },
+    {
+      url = "https://github.com/moyiz/git-dev.nvim/tree/url-parsing",
+      expected = {
+        branch = "url-parsing",
+        repo_url = "https://github.com/moyiz/git-dev.nvim.git",
+        type = "http",
+      },
+    },
+    {
+      url = "https://github.com/moyiz/git-dev.nvim/blob",
+      expected = {
+        repo_url = "https://github.com/moyiz/git-dev.nvim.git",
+        type = "http",
+      },
+    },
+    {
+      url = "https://github.com/moyiz/git-dev.nvim/dummy",
+      expected = {
+        repo_url = "https://github.com/moyiz/git-dev.nvim.git",
+        type = "http",
+      },
+    },
+    {
+      url = "https://github.com/echasnovski/mini.nvim.git",
+      expected = {
+        repo_url = "https://github.com/echasnovski/mini.nvim.git",
+        type = "http",
+      },
+    },
+    {
+      url = "https://github.com/echasnovski/mini.nvim",
+      expected = {
+        repo_url = "https://github.com/echasnovski/mini.nvim.git",
+        type = "http",
+      },
+    },
+    {
+      url = "https://github.com/echasnovski/mini.nvim///",
+      expected = {
+        repo_url = "https://github.com/echasnovski/mini.nvim.git",
+        type = "http",
+      },
+    },
+    {
+      url = "https://github.com/echasnovski/mini.nvim/tree/stable",
+      expected = {
+        repo_url = "https://github.com/echasnovski/mini.nvim.git",
+        branch = "stable",
+        type = "http",
+      },
+    },
+    {
+      url = "https://github.com/echasnovski/mini.nvim/tree/v0.12.0",
+      expected = {
+        repo_url = "https://github.com/echasnovski/mini.nvim.git",
+        branch = "v0.12.0",
+        type = "http",
+      },
+    },
+    {
+      url = "https://github.com/echasnovski/mini.nvim/blob/main/README.md",
+      expected = {
+        repo_url = "https://github.com/echasnovski/mini.nvim.git",
+        full_blob = "main/README.md",
+        type = "http",
+      },
+    },
+    {
+      url = "https://github.com/echasnovski/mini.nvim/blob/stable/README.md",
+      expected = {
+        repo_url = "https://github.com/echasnovski/mini.nvim.git",
+        full_blob = "stable/README.md",
+        type = "http",
+      },
+    },
+    {
+      url = "https://github.com/echasnovski/mini.nvim/blob/main/lua/mini/basics.lua",
+      expected = {
+        repo_url = "https://github.com/echasnovski/mini.nvim.git",
+        full_blob = "main/lua/mini/basics.lua",
+        type = "http",
+      },
+    },
+    {
+      url = "https://github.com/echasnovski/mini.nvim/blob/0cdf41afab4f13b7529d9965cff9c3d2d67b0bfb/lua/mini/statusline.lua",
+      expected = {
+        repo_url = "https://github.com/echasnovski/mini.nvim.git",
+        commit = "0cdf41afab4f13b7529d9965cff9c3d2d67b0bfb",
+        selected_path = "lua/mini/statusline.lua",
+        type = "http",
+      },
+    },
+    {
+      -- branch name: `features/reuse-only`
+      url = "https://github.com/spack/spack/tree/features/reuse-only ",
+      expected = {
+        repo_url = "https://github.com/spack/spack.git",
+        branch = "features/reuse-only",
+        type = "http",
+      },
+    },
+    {
+      url = "https://github.com/spack/spack/blob/features/reuse-only/.github/dependabot.yml",
+      expected = {
+        repo_url = "https://github.com/spack/spack.git",
+        full_blob = "features/reuse-only/.github/dependabot.yml",
+        type = "http",
+      },
+    },
+    -- Gitlab URLs
+    {
+      url = "https://gitlab.com/gitlab-org/code-creation/repository-x-ray.git",
+      expected = {
+        repo_url = "https://gitlab.com/gitlab-org/code-creation/repository-x-ray.git",
+        type = "http",
+      },
+    },
+    {
+      url = "https://gitlab.com/gitlab-org/code-creation/repository-x-ray/-/blob/main/.gitlab/CODEOWNERS?ref_type=heads",
+      expected = {
+        repo_url = "https://gitlab.com/gitlab-org/code-creation/repository-x-ray.git",
+        branch = "main",
+        selected_path = ".gitlab/CODEOWNERS",
+        type = "http",
+      },
+      remote_refs = {
+        { commit_id = "1", ref = "refs/heads/main" },
+      },
+    },
+    {
+      url = "https://gitlab.com/gitlab-org/code-creation/repository-x-ray/-/blob/1.2.0/.gitlab/CODEOWNERS",
+      expected = {
+        repo_url = "https://gitlab.com/gitlab-org/code-creation/repository-x-ray.git",
+        branch = "1.2.0",
+        selected_path = ".gitlab/CODEOWNERS",
+        type = "http",
+      },
+      remote_refs = {
+        { commit_id = "1", ref = "refs/tags/1.2.0" },
+      },
+    },
+    {
+      url = "https://gitlab.com/gitlab-org/code-creation/repository-x-ray/-/tree/1.1.0",
+      expected = {
+        repo_url = "https://gitlab.com/gitlab-org/code-creation/repository-x-ray.git",
+        branch = "1.1.0",
+        type = "http",
+      },
+    },
+    {
+      url = "https://gitlab.com/gitlab-org/code-creation/repository-x-ray/-/blob/010e6076637568b291b7563e089175130ce72369/cmd/scan/main.go",
+      expected = {
+        repo_url = "https://gitlab.com/gitlab-org/code-creation/repository-x-ray.git",
+        commit = "010e6076637568b291b7563e089175130ce72369",
+        selected_path = "cmd/scan/main.go",
+        type = "http",
+      },
+    },
+    {
+      -- branch name: acook/generic_docker_source_entry
+      url = "https://gitlab.com/gitlab-org/code-creation/repository-x-ray/-/blob/acook/generic_docker_source_entry/cmd/scan/main.go ",
+      expected = {
+        repo_url = "https://gitlab.com/gitlab-org/code-creation/repository-x-ray.git",
+        branch = "acook/generic_docker_source_entry",
+        selected_path = "cmd/scan/main.go",
+        type = "http",
+      },
+      remote_refs = {
+        { commit_id = "1", ref = "refs/heads/acook" },
+        {
+          commit_id = "2",
+          ref = "refs/heads/acook/generic_docker_source_entry",
+        },
+        { commit_id = "3", ref = "refs/tags/main" },
+      },
+    },
+    -- Codeberg URLs
+    {
+      url = "https://codeberg.org/FreeBSD/freebsd-ports",
+      expected = {
+        repo_url = "https://codeberg.org/FreeBSD/freebsd-ports.git",
+        type = "http",
+      },
+    },
+    {
+      url = "https://codeberg.org/FreeBSD/freebsd-ports///",
+      expected = {
+        repo_url = "https://codeberg.org/FreeBSD/freebsd-ports.git",
+        type = "http",
+      },
+    },
+    {
+      url = "https://codeberg.org/FreeBSD/freebsd-ports/src/branch/2024Q2 ",
+      expected = {
+        repo_url = "https://codeberg.org/FreeBSD/freebsd-ports.git",
+        branch = "2024Q2",
+        type = "http",
+      },
+    },
+    {
+      url = "https://codeberg.org/FreeBSD/freebsd-ports/raw/branch/2024Q2 ",
+      expected = {
+        repo_url = "https://codeberg.org/FreeBSD/freebsd-ports.git",
+        branch = "2024Q2",
+        type = "http",
+      },
+    },
+    {
+      url = "https://codeberg.org/FreeBSD/freebsd-ports/raw/branch/2024Q2/some/file ",
+      expected = {
+        repo_url = "https://codeberg.org/FreeBSD/freebsd-ports.git",
+        branch = "2024Q2",
+        selected_path = "some/file",
+        type = "http",
+      },
+      remote_refs = {
+        { commit_id = "1", ref = "refs/heads/2024Q2" },
+      },
+    },
+    {
+      -- tag: release/13.3.0
+      url = "https://codeberg.org/FreeBSD/freebsd-ports/src/tag/release/13.3.0 ",
+      expected = {
+        repo_url = "https://codeberg.org/FreeBSD/freebsd-ports.git",
+        branch = "release/13.3.0",
+        type = "http",
+      },
+      remote_refs = {
+        { commit_id = 1, ref = "refs/tags/release/13.3.0" },
+      },
+    },
+    {
+      -- branch name: renovate/vue-monorepo
+      url = "https://codeberg.org/forgejo/forgejo/src/branch/renovate/vue-monorepo/cmd/admin.go ",
+      expected = {
+        branch = "renovate/vue-monorepo",
+        repo_url = "https://codeberg.org/forgejo/forgejo.git",
+        selected_path = "cmd/admin.go",
+        type = "http",
+      },
+      remote_refs = {
+        { commit_id = "1", ref = "refs/heads/renovate/vue-monorepo" },
+        { commit_id = "2", ref = "refs/heads/renovate" },
+      },
+    },
+    {
+      url = "https://codeberg.org/forgejo/forgejo/src/commit/5f82ead13cb7706d3f660271d94de6101cef4119/cmd/admin.go",
+      expected = {
+        repo_url = "https://codeberg.org/forgejo/forgejo.git",
+        commit = "5f82ead13cb7706d3f660271d94de6101cef4119",
+        selected_path = "cmd/admin.go",
+        type = "http",
+      },
+    },
+    {
+      url = "https://codeberg.org/forgejo/forgejo/src/",
+      expected = {
+        repo_url = "https://codeberg.org/forgejo/forgejo.git",
+        type = "http",
+      },
+    },
+    {
+      url = "https://codeberg.org/forgejo/forgejo/src/commit",
+      expected = {
+        repo_url = "https://codeberg.org/forgejo/forgejo.git",
+        type = "http",
+      },
+    },
+    {
+      url = "https://codeberg.org/forgejo/forgejo/src/branch",
+      expected = {
+        repo_url = "https://codeberg.org/forgejo/forgejo.git",
+        type = "http",
+      },
+    },
+    {
+      url = "https://codeberg.org/forgejo/forgejo/src/branch/tag",
+      expected = {
+        branch = "tag",
+        repo_url = "https://codeberg.org/forgejo/forgejo.git",
+        type = "http",
+      },
+    },
+
+    {
+      url = "https://codeberg.org/forgejo/forgejo/src/branch/renovate/postcss-packages",
+      expected = {
+        repo_url = "https://codeberg.org/forgejo/forgejo.git",
+        type = "http",
+        branch = "renovate/postcss-packages",
+      },
+      remote_refs = {
+        { id = "1", ref = "refs/heads/renovate/postcss-packages" },
+      },
+    },
+    {
+      url = "moyiz/na",
+      expected = {
+        repo_url = "https://github.com/moyiz/na.git",
+        type = "base_uri",
+      },
+      base_uri_format = "https://github.com/%s.git",
+    },
+    {
+      url = "test",
+      expected = {
+        repo_url = "this is a test",
+        type = "base_uri",
+      },
+      base_uri_format = "this is a %s",
+    },
+
+    -- SSH
+    {
+      url = "git@git.localhost:/path/to/file",
+      expected = {
+        repo_url = "git@git.localhost:/path/to/file",
+        type = "ssh",
+      },
+    },
+    {
+      url = "ssh://git@git.localhost",
+      expected = {
+        repo_url = "ssh://git@git.localhost",
+        type = "raw",
+      },
+    },
+    -- Non existing domain to parser mapping
+    {
+      url = "https://a.b.c/bla.git",
+      expected = {
+        repo_url = "https://a.b.c/bla.git",
+        type = "raw",
+      },
+    },
+  }
+
+  local function test_parsers(cases)
+    local failed = 0
+    for i, case in ipairs(cases) do
+      local parser = Parser:init {
+        gitcmd = {
+          list_refs = function(_)
+            return case.remote_refs or {}
+          end,
+        },
+        base_uri_format = case.base_uri_format,
+        default_org = case.default_org,
+      }
+      local output = parser:parse(case.url)
+      local passed = vim.deep_equal(output, case.expected)
+      print(
+        i .. ":",
+        passed and "[PASSED]" or "[FAILED]",
+        "- " .. case.url .. "\n"
+      )
+      if not passed then
+        print "Expected:"
+        vim.print(case.expected)
+        print "Output:"
+        vim.print(output)
+        failed = failed + 1
+      end
+    end
+    vim.print(
+      string.format("%d/%d tests have passed!\n", #cases - failed, #cases)
+    )
+    require("os").exit(failed == 0)
+  end
+
+  test_parsers(test_cases)
+end
+return T


### PR DESCRIPTION
Experimental URL parsing support.

The previous parsing engine was simple:
1. If it contains `://`, pass along as is.
2. Otherwise, apply default organization and base URI if needed.

This PR adds much more capabilities to how `git-dev.nvim` treats URIs, where the main focus is to accepts any URL from the web browser (for selected Git providers).

It will try to extract branch / tag / commit ID and the currently viewed file inside the repository.

closes: https://github.com/moyiz/git-dev.nvim/issues/2