### PR TITLE
fix: substitute ':' to '__' in git_uri_to_dir_name

### DIFF
--- a/lua/git-dev/init.lua
+++ b/lua/git-dev/init.lua
@@ -127,7 +127,7 @@ end
 -- "https://github.com/example/repo.git" => "github.com__example__repo"
 local function git_uri_to_dir_name(uri, branch)
   local dir_name =
-    uri:gsub("/+$", ""):gsub(".*://", ""):gsub("/", "__"):gsub(".git$", "")
+    uri:gsub("/+$", ""):gsub(".*://", ""):gsub("[/:]", "__"):gsub(".git$", "")
   if branch and branch ~= "" then
     dir_name = dir_name .. "#" .. branch:gsub("/", "__")
   end


### PR DESCRIPTION
`:` has a special meaning in Windows.

Closes #18 