### PR TITLE
[Feature] XDG URI handler

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -31,6 +31,6 @@ jobs:
         run: nvim --headless --clean -c "helptags doc/" -c qa
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "doc: auto generate"
+          commit_message: "docs: auto generate"
           branch: ${{ github.head_ref }}
           file_pattern: doc

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ tag:
 		echo | tee -a $$MSG_FILE; \
 		git log --pretty=format:%s --invert-grep --grep doc:* $(LATEST_TAG)..HEAD | tee -a $$MSG_FILE; \
 		echo; \
-		echo git tag -a $(TAG) -F $$MSG_FILE; \
+		git tag -a $(TAG) -F $$MSG_FILE; \
 	else \
 		echo "Missing TAG definition."; \
 	fi

--- a/lua/git-dev/gitcmd.lua
+++ b/lua/git-dev/gitcmd.lua
@@ -21,31 +21,10 @@ end
 ---Spawns a command and returns its handle and std{out,err} pipes.
 ---@param cmd string
 function GitCmd:_spawn(cmd, callback)
-  local stdout = uv.new_pipe()
-  local stderr = uv.new_pipe()
-
-  local handle
-  handle = uv.spawn(
-    "sh",
-    { args = { "-c", cmd }, stdio = { nil, stdout, stderr } },
-    function(code)
-      if callback then
-        callback(code)
-      end
-      if handle then
-        handle:close()
-      end
-      stdout:read_stop()
-      stdout:close()
-      stderr:read_stop()
-      stderr:close()
-    end
-  )
-
-  uv.read_start(stdout, self.on_output)
-  uv.read_start(stderr, self.on_output)
-
-  return { handle = handle, stdout = stdout, stderr = stderr }
+  local s = require("git-dev.utils").sh_spawn(cmd, callback)
+  uv.read_start(s.stdout, self.on_output)
+  uv.read_start(s.stderr, self.on_output)
+  return s
 end
 
 ---@class CloneOpts

--- a/lua/git-dev/store.lua
+++ b/lua/git-dev/store.lua
@@ -88,7 +88,7 @@ end
 
 function Store._write(path, data, callback)
   uv.fs_open(path, "w", o600, function(err1, fd)
-    if err1 then
+    if err1 or not fd then
       log_err("Error opening " .. path .. ": " .. err1)
       return
     end
@@ -123,7 +123,7 @@ function Store:load()
     return
   end
   local fd, err = uv.fs_open(self.path, "r", o600)
-  if err then
+  if err or not fd then
     log_err(err)
     return
   end

--- a/lua/git-dev/xdg.lua
+++ b/lua/git-dev/xdg.lua
@@ -1,0 +1,90 @@
+---@class XDGDesktopEntry
+---@field name string
+---@field exec string
+---@field mime_type string
+
+local XDG = {}
+
+local uv = vim.uv
+local utils = require "git-dev.utils"
+
+---@param uri string?
+XDG.handle = function(uri)
+  if not uri then
+    return
+  end
+  -- Trim
+  uri = uri:gsub("^%s+", ""):gsub("%s+$", "")
+  local method = uri:match "://([^/]+)"
+  local params = vim.split(uri, "?")[2]
+  local parsed = {}
+  for _, param in ipairs(vim.split(params, "&")) do
+    local k, v = unpack(vim.split(param, "="))
+    parsed[k] = utils.load_param(vim.uri_decode(v))
+  end
+  return require("git-dev")[method](unpack(vim.tbl_values(parsed)))
+end
+
+---@param entry XDGDesktopEntry
+local function generate_entry(entry)
+  return ([[
+    [Desktop Entry]
+    Name=%s
+    Type=Application
+    Exec=%s
+    Terminal=true
+    MimeType=%s
+    NoDisplay=true
+  ]]):gsub("  +", ""):format(entry.name, entry.exec, entry.mime_type)
+end
+
+XDG.enable = function(opts)
+  utils.overwrite_if_changed(opts.script.path, opts.script.content, utils.o700)
+  local desktop_entry = {
+    name = "GitDev",
+    exec = vim.fn.expand(opts.script.path) .. " %u",
+    mime_type = "x-scheme-handler/nvim-gitdev",
+  }
+
+  utils.overwrite_if_changed(
+    opts.desktop_entry_path,
+    generate_entry(desktop_entry)
+  )
+
+  -- Update scheme handler if incorrect
+  local sh_spawn = require("git-dev.utils").sh_spawn
+  local s = sh_spawn(
+    "xdg-mime query default " .. desktop_entry.mime_type,
+    function(code)
+      if code ~= 0 then
+        vim.api.nvim_err_writeln "Failed to get default handler"
+      end
+    end
+  )
+  uv.read_start(s.stdout, function(err, data)
+    if not err and data then
+      local entry_name = vim.fs.basename(opts.desktop_entry_path)
+      if entry_name ~= vim.trim(data) then
+        sh_spawn(
+          "xdg-mime default " .. entry_name .. " " .. desktop_entry.mime_type,
+          function(code)
+            if code ~= 0 then
+              vim.api.nvim_err_writeln "Failed to set default handler"
+            end
+          end
+        )
+      end
+    end
+  end)
+end
+
+XDG.disable = function(opts)
+  if uv.fs_stat(opts.script.path) then
+    uv.fs_unlink(opts.script.path)
+  end
+  if uv.fs_stat(opts.desktop_entry_path) then
+    uv.fs_unlink(opts.desktop_entry_path)
+  end
+end
+
+return XDG


### PR DESCRIPTION
Adds a new configuration parameter: `xdg_handler`.
When enabled, it will setup a desktop entry and a launcher script, and set it to default handler of `nvim-gitdev://` URIs.

See README for more info.

Closes #11 
Closes #17 