### PR TITLE
docs(README): lazy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Lazier (documentation will not be available until first use):
     "GitDevOpen",
     "GitDevRecents",
     "GitDevToggleUI",
+    "GitDevXDGHandle",
   },
   opts = {},
 }


### PR DESCRIPTION
closes: https://github.com/moyiz/git-dev.nvim/issues/23

xdg-open did not work because `git-dev` was not loaded