### PR TITLE
feat: allow disabling builtin UI in favor of vim.notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ M.config = {
   },
   -- UI configuration.
   ui = {
+    -- Whether to enable builtin output buffer or fallback to `vim.notify`.
+    enabled = true,
     -- Auto-close window after repository was opened.
     auto_close = true,
     -- Delay window closing.

--- a/lua/git-dev/ui.lua
+++ b/lua/git-dev/ui.lua
@@ -111,6 +111,8 @@ function UI:print(...)
   return self
 end
 
+function UI:emit() end
+
 ---Closes window after given delay.
 ---@param delay? integer Time to wait before closing the window in ms.
 function UI:close(delay)

--- a/lua/git-dev/uistub.lua
+++ b/lua/git-dev/uistub.lua
@@ -1,0 +1,52 @@
+---A UI stub, implementing the same API as UI class.
+---It concatenates with each `print` invocation, and displays text once closed
+---with a single call to `vim.notify`.
+---@class UIStub
+local UIStub = {}
+
+function UIStub:init(o)
+  setmetatable(o or {}, self)
+  self.__index = self
+  return o
+end
+
+function UIStub:show(_)
+  return self
+end
+
+function UIStub:redraw() end
+function UIStub:toggle(_) end
+
+local st = ""
+
+function UIStub:print(...)
+  -- Transform arguments into a space delimited string and append '\n'.
+  local args = { ... }
+  local s = ""
+  for i = 1, #args do
+    if type(args[i]) == "string" then
+      s = s .. " " .. args[i]
+    else
+      s = s .. " " .. vim.inspect(args[i])
+    end
+  end
+  s = s .. "\n"
+  vim.schedule(function()
+    st = st .. s
+  end)
+  return self
+end
+
+function UIStub:emit(_)
+  -- Schedule the write.
+  vim.schedule(function()
+    vim.notify(st)
+    st = ""
+  end)
+end
+
+function UIStub:close()
+  self:emit()
+end
+
+return UIStub


### PR DESCRIPTION
Adds a new configuration option to allow disabling UI.

To disale:
```lua
{
  ui = {
    enabled = false,
  }
}
```

It will fallback to `vim.notify` and will show two notifications:
1. Opening ... - When calling `open`.
2. An aggregated notification of all output from this point until `open` exists.

Closes #26