### PR TITLE
feat: do not store home directory in desktop entry

### DIFF
--- a/lua/git-dev/xdg.lua
+++ b/lua/git-dev/xdg.lua
@@ -46,8 +46,9 @@ XDG.enable = function(opts)
     exec = script_path .. " %u",
     mime_type = "x-scheme-handler/nvim-gitdev",
   }
-  if script_path == vim.fn.expand "~/.local/bin/git-dev-open" then
-    desktop_entry.exec = "git-dev-open %u"
+  local script_name = script_path:match "([^/]+)$"
+  if script_path == vim.fn.expand("~/.local/bin/" .. script_name) then
+    desktop_entry.exec = script_name .. " %u"
   end
 
   utils.overwrite_if_changed(

--- a/lua/git-dev/xdg.lua
+++ b/lua/git-dev/xdg.lua
@@ -40,11 +40,15 @@ end
 
 XDG.enable = function(opts)
   utils.overwrite_if_changed(opts.script.path, opts.script.content, utils.o700)
+  local script_path = vim.fn.expand(opts.script.path)
   local desktop_entry = {
     name = "GitDev",
-    exec = vim.fn.expand(opts.script.path) .. " %u",
+    exec = script_path .. " %u",
     mime_type = "x-scheme-handler/nvim-gitdev",
   }
+  if script_path == vim.fn.expand "~/.local/bin/git-dev-open" then
+    desktop_entry.exec = "git-dev-open %u"
+  end
 
   utils.overwrite_if_changed(
     opts.desktop_entry_path,

--- a/lua/git-dev/xdg.lua
+++ b/lua/git-dev/xdg.lua
@@ -40,16 +40,16 @@ end
 
 XDG.enable = function(opts)
   utils.overwrite_if_changed(opts.script.path, opts.script.content, utils.o700)
+
   local script_path = vim.fn.expand(opts.script.path)
+  local binary_name = vim.fn.fnamemodify(script_path, ":t")
+  local exe_path = vim.fn.exepath(binary_name)
+
   local desktop_entry = {
     name = "GitDev",
-    exec = script_path .. " %u",
+    exec = ((exe_path ~= "" and binary_name) or script_path) .. " %u",
     mime_type = "x-scheme-handler/nvim-gitdev",
   }
-  local script_name = script_path:match "([^/]+)$"
-  if script_path == vim.fn.expand("~/.local/bin/" .. script_name) then
-    desktop_entry.exec = script_name .. " %u"
-  end
 
   utils.overwrite_if_changed(
     opts.desktop_entry_path,


### PR DESCRIPTION
when `git-dev-open` is installed in `~/.local/bin`, the `.desktop` file can reference the binary name directly. This avoids embedding user-specific home directory paths in dotfiles or repos