### PR TITLE
Fixed and improved history window closing

### DIFF
--- a/lua/git-dev/pickers/init.lua
+++ b/lua/git-dev/pickers/init.lua
@@ -29,13 +29,15 @@ local P = {
       end,
       -- Action on selection
       select_entry = function(entry)
-        if entry then
-          require("git-dev").open(
-            entry.args.repo,
-            entry.args.ref,
-            entry.args.opts
-          )
-        end
+        vim.schedule(function()
+          if entry then
+            require("git-dev").open(
+              entry.args.repo,
+              entry.args.ref,
+              entry.args.opts
+            )
+          end
+        end)
       end,
       -- An array of an entry text parts
       label_parts = function(entry)

--- a/lua/git-dev/pickers/mini.lua
+++ b/lua/git-dev/pickers/mini.lua
@@ -12,7 +12,10 @@ function pickers.history(local_opts)
     source = {
       name = config.title,
       items = config.get_entries,
-      choose = config.select_entry,
+      choose = function(item)
+        minipick.stop()
+        config.select_entry(item)
+      end,
       show = function(buf_id, items)
         local widths = picker_utils.normalize_width(
           vim.fn.winwidth(0), -- should deduct separator width

--- a/lua/git-dev/pickers/snacks.lua
+++ b/lua/git-dev/pickers/snacks.lua
@@ -13,7 +13,10 @@ function pickers.history(local_opts)
     source = "git-dev",
     title = config.title,
     items = config.get_entries(),
-    confirm = function(_, item)
+    confirm = function(picker, item)
+      if picker then
+        picker:close()
+      end
       config.select_entry(item)
     end,
     format = function(item, p)


### PR DESCRIPTION
Improved the history picker window closing by adding a small delay and fixed the issue where the window remained visible when selecting a repository in an non-telescope picker.

**Changes:**
- Added explicit window closing for Snacks (`picker:close()`), Mini.pick (`minipick.stop()`), and vim.ui.select pickers
- Added 50ms deferred call to `select_entry()` for all pickers (Snacks, Telescope, Mini.pick, vim.ui.select) to process the close commands and ensure a clean visual transition

Closes #38 
